### PR TITLE
Fix project description and lock down Actions permissions

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -11,8 +11,8 @@ const projects: Project[] = [
   {
     title: 'N2 Solutions Website',
     description:
-      'This site. Built with Astro, React, and Tailwind CSS. Hosted on AWS S3 + CloudFront with IaC via OpenTofu and Terragrunt.',
-    tags: ['Astro', 'React', 'Tailwind', 'AWS', 'OpenTofu'],
+      'This site. Built with Astro, React, and Tailwind CSS. Hosted on AWS S3 + CloudFront with CI/CD via GitHub Actions.',
+    tags: ['Astro', 'React', 'Tailwind', 'AWS', 'GitHub Actions'],
     repo: 'https://github.com/n2solutionsio/website',
     status: 'active',
   },


### PR DESCRIPTION
## Summary
- Fix N2 Solutions Website project card description — removed incorrect "IaC via OpenTofu and Terragrunt" and replaced with "CI/CD via GitHub Actions"
- Updated project tags: swapped `OpenTofu` for `GitHub Actions`
- Restricted GitHub Actions to only allow GitHub-owned and verified marketplace actions (configured via API, not in this diff)

## Test plan
- [ ] Verify project card on /projects page shows updated description and tags
- [ ] Confirm CI pipeline still passes with restricted Actions permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)