### PR TITLE
Add gallery auto-discovery system with album support

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,7 @@ export default [
       ...tseslint.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
       'react/react-in-jsx-scope': 'off',
+      'no-undef': 'off', // TypeScript handles this natively
     },
     settings: {
       react: { version: 'detect' },

--- a/src/components/GalleryFilter.tsx
+++ b/src/components/GalleryFilter.tsx
@@ -1,22 +1,47 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   categoryLabels,
+  type Album,
   type GalleryCategory,
-  type Photo,
 } from '../data/gallery';
 
 interface Props {
-  photos: Photo[];
+  albums: Album[];
+  initialCategory: string;
 }
 
-export default function GalleryFilter({ photos }: Props) {
-  const [active, setActive] = useState<GalleryCategory | 'all'>('all');
+export default function GalleryFilter({ albums, initialCategory }: Props) {
+  const [active, setActive] = useState<GalleryCategory | 'all'>(
+    isValidCategory(initialCategory) ? initialCategory : 'all',
+  );
+
+  // Sync with browser back/forward
+  useEffect(() => {
+    function onPopState() {
+      const params = new URLSearchParams(window.location.search);
+      const cat = params.get('category') ?? 'all';
+      setActive(isValidCategory(cat) ? cat : 'all');
+    }
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
+
+  function handleFilter(cat: GalleryCategory | 'all') {
+    setActive(cat);
+    const url = new URL(window.location.href);
+    if (cat === 'all') {
+      url.searchParams.delete('category');
+    } else {
+      url.searchParams.set('category', cat);
+    }
+    window.history.pushState({}, '', url.toString());
+  }
 
   const categories = Object.keys(categoryLabels) as GalleryCategory[];
   const filtered =
-    active === 'all' ? photos : photos.filter((p) => p.category === active);
+    active === 'all' ? albums : albums.filter((a) => a.category === active);
 
-  if (photos.length === 0) {
+  if (albums.length === 0) {
     return (
       <div className="rounded-lg border border-border/50 bg-bg-secondary/50 p-12 text-center">
         <p className="text-text-muted">Photos coming soon.</p>
@@ -26,9 +51,10 @@ export default function GalleryFilter({ photos }: Props) {
 
   return (
     <div>
+      {/* Filter pills */}
       <div className="mb-8 flex flex-wrap gap-2">
         <button
-          onClick={() => setActive('all')}
+          onClick={() => handleFilter('all')}
           aria-pressed={active === 'all'}
           className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
             active === 'all'
@@ -41,7 +67,7 @@ export default function GalleryFilter({ photos }: Props) {
         {categories.map((cat) => (
           <button
             key={cat}
-            onClick={() => setActive(cat)}
+            onClick={() => handleFilter(cat)}
             aria-pressed={active === cat}
             className={`rounded-full px-4 py-1.5 text-sm font-medium transition-colors ${
               active === cat
@@ -54,26 +80,58 @@ export default function GalleryFilter({ photos }: Props) {
         ))}
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {filtered.map((photo, i) => (
-          <div
-            key={i}
-            className="group overflow-hidden rounded-lg border border-border/50"
-          >
-            <img
-              src={photo.src}
-              alt={photo.alt}
-              className="aspect-[4/3] w-full object-cover transition-transform group-hover:scale-105"
-              loading="lazy"
-            />
-            {photo.caption && (
-              <div className="bg-bg-secondary p-3">
-                <p className="text-sm text-text-muted">{photo.caption}</p>
+      {/* Album sections */}
+      {filtered.length === 0 ? (
+        <div className="rounded-lg border border-border/50 bg-bg-secondary/50 p-12 text-center">
+          <p className="text-text-muted">No photos in this category yet.</p>
+        </div>
+      ) : (
+        <div className="space-y-12">
+          {filtered.map((album) => (
+            <section key={`${album.category}-${album.slug}`}>
+              <div className="mb-4">
+                <h2 className="text-xl font-bold">{album.title}</h2>
+                {album.date && (
+                  <p className="text-sm text-text-muted">
+                    {formatDate(album.date)}
+                  </p>
+                )}
               </div>
-            )}
-          </div>
-        ))}
-      </div>
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {album.photos.map((photo, i) => (
+                  <div
+                    key={i}
+                    className="group overflow-hidden rounded-lg border border-border/50"
+                  >
+                    <img
+                      src={photo.src}
+                      alt={photo.alt}
+                      width={photo.width}
+                      height={photo.height}
+                      className="aspect-[4/3] w-full object-cover transition-transform group-hover:scale-105"
+                      loading="lazy"
+                    />
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
     </div>
   );
+}
+
+function isValidCategory(value: string): value is GalleryCategory | 'all' {
+  return value === 'all' || value in categoryLabels;
+}
+
+function formatDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  const date = new Date(year, month - 1, day);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
 }

--- a/src/components/Interests.astro
+++ b/src/components/Interests.astro
@@ -17,6 +17,7 @@ const sections = [
     align: 'left',
     image: sailingPhoto,
     imagePosition: 'center',
+    galleryCategory: 'sailing',
   },
   {
     id: 'motorcycles',
@@ -29,6 +30,7 @@ const sections = [
     align: 'right',
     image: motorcyclePhoto,
     imagePosition: 'center',
+    galleryCategory: 'motorcycles',
   },
   {
     id: 'philly-sports',
@@ -41,6 +43,7 @@ const sections = [
     align: 'left',
     image: phillyLogo,
     imagePosition: 'center',
+    galleryCategory: 'eagles',
   },
   {
     id: 'the-rottweiler',
@@ -53,6 +56,7 @@ const sections = [
     align: 'right',
     image: rhaegarPhoto,
     imagePosition: 'center 25%',
+    galleryCategory: 'pets',
   },
 ];
 ---
@@ -118,6 +122,15 @@ const sections = [
               <p class="leading-relaxed text-text-muted">
                 {section.description}
               </p>
+              {section.galleryCategory && (
+                <a
+                  href={`/gallery?category=${section.galleryCategory}`}
+                  class="mt-4 inline-flex items-center gap-1 text-sm font-medium text-accent transition-colors hover:text-accent/80"
+                >
+                  View Gallery
+                  <span aria-hidden="true">&rarr;</span>
+                </a>
+              )}
             </div>
           </div>
         ))

--- a/src/data/gallery.ts
+++ b/src/data/gallery.ts
@@ -2,8 +2,19 @@ export interface Photo {
   src: string;
   alt: string;
   category: GalleryCategory;
+  width: number;
+  height: number;
+  albumSlug?: string;
+  albumTitle?: string;
+  albumDate?: string;
+}
+
+export interface Album {
+  slug: string;
+  title: string;
   date?: string;
-  caption?: string;
+  category: GalleryCategory;
+  photos: Photo[];
 }
 
 export type GalleryCategory =
@@ -11,6 +22,7 @@ export type GalleryCategory =
   | 'phillies'
   | 'sailing'
   | 'motorcycles'
+  | 'pets'
   | 'events';
 
 export const categoryLabels: Record<GalleryCategory, string> = {
@@ -18,18 +30,6 @@ export const categoryLabels: Record<GalleryCategory, string> = {
   phillies: 'Phillies',
   sailing: 'Sailing',
   motorcycles: 'Motorcycles',
+  pets: 'Pets',
   events: 'Events',
 };
-
-// Photos will be added here as they are uploaded to src/assets/photos/
-// Example entry:
-// {
-//   src: '/photos/eagles/game-day-2026.jpg',
-//   alt: 'Eagles game day at Lincoln Financial Field',
-//   category: 'eagles',
-//   date: '2026-01-12',
-//   caption: 'Divisional round vs Dallas',
-// },
-const photos: Photo[] = [];
-
-export default photos;

--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -1,7 +1,11 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import GalleryFilter from '../components/GalleryFilter';
-import photos from '../data/gallery';
+import { discoverPhotos, groupPhotosByAlbum } from '../utils/gallery';
+
+const photos = await discoverPhotos();
+const albums = groupPhotosByAlbum(photos);
+const initialCategory = Astro.url.searchParams.get('category') ?? 'all';
 ---
 
 <BaseLayout
@@ -17,6 +21,10 @@ import photos from '../data/gallery';
       Moments from the stands, the water, the road, and everything in between.
     </p>
 
-    <GalleryFilter photos={photos} client:idle />
+    <GalleryFilter
+      albums={albums}
+      initialCategory={initialCategory}
+      client:idle
+    />
   </div>
 </BaseLayout>

--- a/src/utils/gallery.ts
+++ b/src/utils/gallery.ts
@@ -1,0 +1,129 @@
+import { getImage } from 'astro:assets';
+import type { Album, GalleryCategory, Photo } from '../data/gallery';
+import { categoryLabels } from '../data/gallery';
+
+// Glob all images under src/assets/photos/ at build time
+const imageModules = import.meta.glob<{ default: ImageMetadata }>(
+  '../assets/photos/**/*.{jpg,jpeg,png,webp}',
+  { eager: true },
+);
+
+const VALID_CATEGORIES = new Set(Object.keys(categoryLabels));
+
+/** Parse an album slug like "2025-09-07-cowboys" → { date, title } */
+function parseAlbumSlug(slug: string): { date?: string; title: string } {
+  const dateMatch = slug.match(/^(\d{4}-\d{2}-\d{2})-(.+)$/);
+  if (dateMatch) {
+    return { date: dateMatch[1], title: formatSlugTitle(dateMatch[2]) };
+  }
+  return { title: formatSlugTitle(slug) };
+}
+
+/** Convert "stadium-tour" → "Stadium Tour" */
+function formatSlugTitle(slug: string): string {
+  return slug
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+/** Generate alt text from filename: "game-day-2026.jpg" → "Game Day 2026" */
+function fileToAlt(filename: string): string {
+  const name = filename.replace(/\.[^.]+$/, '');
+  return formatSlugTitle(name);
+}
+
+/**
+ * Discover all photos from the file system and optimize them.
+ * Returns a flat array of Photo objects with optimized src URLs.
+ */
+export async function discoverPhotos(): Promise<Photo[]> {
+  const photos: Photo[] = [];
+
+  for (const [path, mod] of Object.entries(imageModules)) {
+    // path looks like: ../assets/photos/sailing/sailing-philly.jpg
+    // or: ../assets/photos/eagles/2025-09-07-cowboys/photo.jpg
+    const segments = path.split('/');
+    const photosIdx = segments.indexOf('photos');
+    if (photosIdx === -1) continue;
+
+    const afterPhotos = segments.slice(photosIdx + 1);
+    // afterPhotos: ["sailing", "sailing-philly.jpg"]
+    // or: ["eagles", "2025-09-07-cowboys", "photo.jpg"]
+
+    if (afterPhotos.length < 2) continue;
+
+    const category = afterPhotos[0];
+    if (!VALID_CATEGORIES.has(category)) continue;
+
+    const filename = afterPhotos[afterPhotos.length - 1];
+    // Skip hidden files
+    if (filename.startsWith('.')) continue;
+
+    const original = mod.default;
+    const optimized = await getImage({
+      src: original,
+      width: 800,
+      format: 'webp',
+    });
+
+    const photo: Photo = {
+      src: optimized.src,
+      alt: fileToAlt(filename),
+      category: category as GalleryCategory,
+      width: (optimized.attributes.width as number) ?? 800,
+      height: (optimized.attributes.height as number) ?? 600,
+    };
+
+    // Check if this is inside an album subfolder
+    if (afterPhotos.length >= 3) {
+      const albumSlug = afterPhotos[1];
+      const parsed = parseAlbumSlug(albumSlug);
+      photo.albumSlug = albumSlug;
+      photo.albumTitle = parsed.title;
+      photo.albumDate = parsed.date;
+    }
+
+    photos.push(photo);
+  }
+
+  return photos;
+}
+
+/**
+ * Group a flat list of photos into albums, sorted newest-first.
+ * Loose photos (no album folder) are grouped under a default album.
+ */
+export function groupPhotosByAlbum(photos: Photo[]): Album[] {
+  const albumMap = new Map<string, Album>();
+
+  for (const photo of photos) {
+    const key = photo.albumSlug
+      ? `${photo.category}/${photo.albumSlug}`
+      : `${photo.category}/_loose`;
+
+    if (!albumMap.has(key)) {
+      albumMap.set(key, {
+        slug: photo.albumSlug ?? `${photo.category}-photos`,
+        title: photo.albumTitle ?? categoryLabels[photo.category],
+        date: photo.albumDate,
+        category: photo.category,
+        photos: [],
+      });
+    }
+
+    albumMap.get(key)!.photos.push(photo);
+  }
+
+  const albums = Array.from(albumMap.values());
+
+  // Sort: dated albums newest-first, then undated alphabetically
+  albums.sort((a, b) => {
+    if (a.date && b.date) return b.date.localeCompare(a.date);
+    if (a.date) return -1;
+    if (b.date) return 1;
+    return a.title.localeCompare(b.title);
+  });
+
+  return albums;
+}


### PR DESCRIPTION
## Summary
- Auto-discover photos from `src/assets/photos/` at build time via `import.meta.glob` — no code changes needed to add photos
- Album folders (e.g. `2025-09-07-cowboys/`) parse date and title from the slug automatically
- Gallery page supports URL-based category filtering (`/gallery?category=eagles`) with browser back/forward support
- Interest sections on About page now link to the gallery filtered by category ("View Gallery →")
- Added `pets` category to the gallery type system

Closes #22

## Test plan
- [ ] `npm run dev` — gallery page shows existing photos auto-discovered from folders
- [ ] Visit `/gallery?category=sailing` — shows only sailing photos
- [ ] Interest section "View Gallery →" links navigate to correct filtered view
- [ ] Browser back/forward updates the active filter
- [ ] `npm run lint && npm run format:check && npm run typecheck && npm run build` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)