### PR TITLE
Fix gallery category filter for static builds

### DIFF
--- a/src/components/GalleryFilter.tsx
+++ b/src/components/GalleryFilter.tsx
@@ -7,23 +7,21 @@ import {
 
 interface Props {
   albums: Album[];
-  initialCategory: string;
 }
 
-export default function GalleryFilter({ albums, initialCategory }: Props) {
-  const [active, setActive] = useState<GalleryCategory | 'all'>(
-    isValidCategory(initialCategory) ? initialCategory : 'all',
-  );
+export default function GalleryFilter({ albums }: Props) {
+  const [active, setActive] = useState<GalleryCategory | 'all'>('all');
 
-  // Sync with browser back/forward
+  // Read category from URL on mount and sync with browser back/forward
   useEffect(() => {
-    function onPopState() {
+    function syncFromUrl() {
       const params = new URLSearchParams(window.location.search);
       const cat = params.get('category') ?? 'all';
       setActive(isValidCategory(cat) ? cat : 'all');
     }
-    window.addEventListener('popstate', onPopState);
-    return () => window.removeEventListener('popstate', onPopState);
+    syncFromUrl();
+    window.addEventListener('popstate', syncFromUrl);
+    return () => window.removeEventListener('popstate', syncFromUrl);
   }, []);
 
   function handleFilter(cat: GalleryCategory | 'all') {

--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -5,7 +5,6 @@ import { discoverPhotos, groupPhotosByAlbum } from '../utils/gallery';
 
 const photos = await discoverPhotos();
 const albums = groupPhotosByAlbum(photos);
-const initialCategory = Astro.url.searchParams.get('category') ?? 'all';
 ---
 
 <BaseLayout
@@ -21,10 +20,6 @@ const initialCategory = Astro.url.searchParams.get('category') ?? 'all';
       Moments from the stands, the water, the road, and everything in between.
     </p>
 
-    <GalleryFilter
-      albums={albums}
-      initialCategory={initialCategory}
-      client:idle
-    />
+    <GalleryFilter albums={albums} client:idle />
   </div>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Read `?category=` URL param client-side on mount instead of via `Astro.url.searchParams` at build time
- Static builds don't have access to query params, so the filter was always defaulting to "All"
- Removed unused `initialCategory` prop

## Test plan
- [ ] Visit `/gallery?category=sailing` — Sailing pill is highlighted, only sailing photos shown
- [ ] Click filter pills — URL updates, back/forward works
- [ ] All checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)