### PR TITLE
Fix gallery links to use trailing slash for CloudFront

### DIFF
--- a/src/components/Interests.astro
+++ b/src/components/Interests.astro
@@ -124,7 +124,7 @@ const sections = [
               </p>
               {section.galleryCategory && (
                 <a
-                  href={`/gallery?category=${section.galleryCategory}`}
+                  href={`/gallery/?category=${section.galleryCategory}`}
                   class="mt-4 inline-flex items-center gap-1 text-sm font-medium text-accent transition-colors hover:text-accent/80"
                 >
                   View Gallery


### PR DESCRIPTION
## Summary
- CloudFront redirects `/gallery` → `/gallery/` which drops the `?category=` query param
- Updated Interest section "View Gallery →" links to use `/gallery/?category=` so the filter works on the live site

## Test plan
- [ ] Click "View Gallery →" from an Interest section — arrives at gallery with correct filter active
- [ ] All checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)