### PR TITLE
Update homelab project with blog link and full description

### DIFF
--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -44,19 +44,44 @@ const statusColors = {
     }
   </div>
 
-  {
-    project.repo && (
-      <a
-        href={project.repo}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="mt-auto inline-flex items-center gap-1 text-sm font-medium text-accent hover:text-accent-hover"
-      >
-        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
-          <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
-        </svg>
-        View on GitHub
-      </a>
-    )
-  }
+  <div class="mt-auto flex items-center gap-4">
+    {
+      project.url && (
+        <a
+          href={project.url}
+          class="inline-flex items-center gap-1 text-sm font-medium text-accent hover:text-accent-hover"
+        >
+          <svg
+            class="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"
+            />
+          </svg>
+          Read more
+        </a>
+      )
+    }
+    {
+      project.repo && (
+        <a
+          href={project.repo}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center gap-1 text-sm font-medium text-accent hover:text-accent-hover"
+        >
+          <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+          </svg>
+          View on GitHub
+        </a>
+      )
+    }
+  </div>
 </div>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -19,8 +19,18 @@ const projects: Project[] = [
   {
     title: 'Homelab Infrastructure',
     description:
-      'Proxmox-based homelab running Kubernetes, Docker, and various self-hosted services. Fully managed with IaC.',
-    tags: ['Proxmox', 'Kubernetes', 'Docker', 'Terraform', 'Ansible'],
+      'Production-grade homelab — 5 VLANs, 10G backbone, 3-node k3s cluster, full GitOps with ArgoCD, and complete observability. Built with Claude Code as AI co-pilot. All open-source, all IaC.',
+    tags: [
+      'Proxmox',
+      'k3s',
+      'ArgoCD',
+      'OpenTofu',
+      'Terragrunt',
+      'Prometheus',
+      'Grafana',
+    ],
+    repo: 'https://github.com/n2solutionsio/homelab-gitops',
+    url: '/blog/homelab-v1/',
     status: 'active',
   },
 ];


### PR DESCRIPTION
## Summary

- Updates Homelab Infrastructure project description to reflect the completed 10-phase build
- Adds repo link to `homelab-gitops` (public)
- Adds "Read more" link to the blog post (`/blog/homelab-v1/`)
- Adds `url` field rendering to `ProjectCard` component (was defined in interface but unused)
- Updates tags to reflect actual stack (k3s, ArgoCD, OpenTofu, Terragrunt, Prometheus, Grafana)

## Test plan

- [ ] Verify projects page renders updated homelab card
- [ ] "Read more" links to blog post
- [ ] "View on GitHub" links to homelab-gitops repo
- [ ] Both links display correctly side by side

🤖 Generated with [Claude Code](https://claude.com/claude-code)